### PR TITLE
fix: relax rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,6 @@ module.exports = {
     "brace-style": [2, "1tbs", { "allowSingleLine": true }],
     "camelcase": 2,
     "comma-style": 2,
-    "consistent-this": [2, "that"],
     "indent": 2,
     "jsx-quotes": 2,
     "key-spacing": [2, {"beforeColon": false, "afterColon": true}],
@@ -62,6 +61,6 @@ module.exports = {
     "no-dupe-class-members": 2,
     "no-this-before-super": 2,
     "no-var": 2,
-    "yoda": [2, "never", { "exceptRange": true }]
+    "yoda": [2, "never", { "onlyEquality": true }]
   }
 };

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = {
     "brace-style": [2, "1tbs", { "allowSingleLine": true }],
     "camelcase": 2,
     "comma-style": 2,
-    "indent": 2,
+    "indent": [2, 4, { "SwitchCase": 1 }],
     "jsx-quotes": 2,
     "key-spacing": [2, {"beforeColon": false, "afterColon": true}],
     "linebreak-style": [2, "unix"],


### PR DESCRIPTION
1) `consistent-this`: does not make sense to name the field the same way in some cases

``` js
// Invalid code according to the rule
findRoot() {
    let node = this;

    while (node.parent) {
        node = node.parent;
    }

    return node;
}
```

2) `indent.SwitchCase`: by default the indentation of switch and case statements should be the same

``` js
// Invalid code according to the rule
switch (e.field) {
  case "foo":
```

3) `yoda.exceptRange`: does not allow non-literal values

``` js
// Invalid code according to the rule
0 < index < array.length
```
